### PR TITLE
Fix popover position top in ContentVuer

### DIFF
--- a/src/components/ContentVuer.vue
+++ b/src/components/ContentVuer.vue
@@ -177,6 +177,7 @@ export default {
   bottom: 0px;
   position: absolute;
   z-index:6;
+  overflow: hidden;
 }
 
 .dataset-header {


### PR DESCRIPTION
### Issue
The top section of "What's new?" info's popover is hidden. 

### Fix
It is fixed by applying the outer container's overflow hidden in CSS.

### Test
Tested all other components' UI are not affected inside and outside the container.