### PR TITLE
Update content bar styles

### DIFF
--- a/src/components/ContentBar.vue
+++ b/src/components/ContentBar.vue
@@ -344,6 +344,8 @@ export default {
 
   .information-group {
     margin-left: auto;
+    margin-right: 12px;
+    height: 100%;
   }
 
   .toolbar-title {
@@ -354,14 +356,15 @@ export default {
     font-weight: normal;
     line-height: 20px;
     margin-left: 1rem;
-    margin-top: 6px;
   }
 
   .select-box {
+    width: fit-content;
     max-width: 200px;
+    min-width: 0;
     z-index: 5;
     flex-shrink: 1;
-    min-width: 0;
+
     :deep(.el-select__wrapper) {
       color: $app-primary-color;
       height: 29px;


### PR DESCRIPTION
The updates include the following UI fixes.

1. The label alignment
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img width="383" height="146" alt="image" src="https://github.com/user-attachments/assets/c7551ca9-294c-423b-8b17-7ffe82c54b7f" /></td>
<td><img width="272" height="126" alt="image" src="https://github.com/user-attachments/assets/a376003c-5450-4e6f-b2d5-f8105f8223b9" /></td>
</tr>
</table>

#

3. The gap between label and arrow
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>
<img width="388" height="128" alt="image" src="https://github.com/user-attachments/assets/5d954616-c594-417f-9e27-f049af219952" /><td></td><td>
<img width="198" height="87" alt="image" src="https://github.com/user-attachments/assets/6e9fa3bc-0b9e-4dfe-b2ed-da52e35e13af" /></td></tr>
</table>




#

4. The space for the right corner
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>
<img width="238" height="134" alt="image" src="https://github.com/user-attachments/assets/295e56e2-f693-42ad-a8bb-b7b72f1047cb" /></td><td>
<img width="233" height="134" alt="image" src="https://github.com/user-attachments/assets/1d5e03f6-bfe3-4246-962d-7628663769ec" /></td></tr>
</table>





#

5. The space above tooltip 
<img width="301" height="208" alt="image" src="https://github.com/user-attachments/assets/5b5d201e-da52-4d20-9693-39184c679097" />
<img width="295" height="165" alt="image" src="https://github.com/user-attachments/assets/56c90707-ecfc-4157-bec1-11bd2c4d500a" />

