### PR TITLE
Fix context card position on split view switch

### DIFF
--- a/src/components/ContentBar.vue
+++ b/src/components/ContentBar.vue
@@ -339,13 +339,13 @@ export default {
   .shrink {
     flex-shrink: 1;
     min-width: 0;
-    overflow:hidden;
   }
 
   .information-group {
     margin-left: auto;
     margin-right: 12px;
     height: 100%;
+    position: relative;
   }
 
   .toolbar-title {
@@ -356,6 +356,9 @@ export default {
     font-weight: normal;
     line-height: 20px;
     margin-left: 1rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .select-box {


### PR DESCRIPTION
After opening a new view (e.g., a scaffold viewer), the context card is shown in the top-right corner. 
And then, update the split screen to vertical split view. The scaffold viewer and flatmap viewer will split the screen, but the scaffold viewer's context card remains at the top-right corner, over the flatmap viewer's context card. 
Another way to test this bug is on split-screen view, open the context card for each view, and switch the views. 

